### PR TITLE
Add GPU memory usage to dask_memusage plugin.

### DIFF
--- a/test_memusage.py
+++ b/test_memusage.py
@@ -57,6 +57,7 @@ def test_highlevel_python_usage(tmpdir):
     client = Client(cluster)
     compute(make_bag())
     check_csv(tempfile)
+    client.shutdown()
 
 
 def test_commandline_usage(tmpdir):
@@ -77,6 +78,7 @@ def test_commandline_usage(tmpdir):
         client = Client("tcp://127.0.0.1:3333")
         compute(make_bag())
         check_csv(tempfile)
+        client.shutdown()
     finally:
         worker.kill()
         scheduler.kill()


### PR DESCRIPTION
Today, it is almost impossible to monitor GPU usage using dask_memusage. Only regular memory is possible.

With the proposed commits it is possible at least to compare the minimum GPU usage with the memory pick using [GPUtil library](https://github.com/anderskm/gputil).

The only problem with this approach is that we cannot track memory usage by each process by using `nvidia-smi pmon -c 1 -s m` for example. For some reason, this command does not work inside docker containers. It is possible to monitor only from the host system. 